### PR TITLE
feat: support non-templated Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ There are a number of other known issues, gaps and features noted in the [this r
 
 A number of key callouts:
 
-- This does not ([yet](https://github.com/jamietanna/gh-discussion/issues/2)) support creating a Discussion if you do not have Discussion category forms set up
 - This does not (yet) support GitHub Enterprise
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -255,6 +256,8 @@ func (dt *DiscussionTemplateClient) Discover(ctx context.Context) ([]discussion.
 	return categories, resp.Repository.ID, nil
 }
 
+var errDiscussionTemplateNotFound = errors.New("no Discussion template could be found")
+
 func (dt *DiscussionTemplateClient) RetrieveTemplate(ctx context.Context, slug string) (discussionform.Template, error) {
 	gClient := github.NewClient(dt.httpClient)
 
@@ -262,7 +265,7 @@ func (dt *DiscussionTemplateClient) RetrieveTemplate(ctx context.Context, slug s
 
 	f, _, resp, err := gClient.Repositories.GetContents(ctx, dt.repo.Owner, dt.repo.Name, path, nil)
 	if resp.StatusCode == http.StatusNotFound {
-		return discussionform.Template{}, fmt.Errorf("no template could be found at path %s for repository %v/%v", path, dt.repo.Owner, dt.repo.Name)
+		return discussionform.Template{}, fmt.Errorf("no template could be found at path %s for repository %v/%v: %w", path, dt.repo.Owner, dt.repo.Name, errDiscussionTemplateNotFound)
 	} else if err != nil {
 		return discussionform.Template{}, fmt.Errorf("failed to look up template at path %s for repository %v/%v: %w", path, dt.repo.Owner, dt.repo.Name, err)
 	}

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprint(os.Stderr, err.Error()+"\n")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
We can assume that if a template cannot be found for a Discussion, we
can "just" treat it as if it's a body-only Discussion, which is how the
GitHub UI would present it.

If there's a different error trying to retrieve the Discussion template,
we can then return that error.

Closes #2.